### PR TITLE
set py-modules in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+py-modules = ["huggingbutt"]
+
 [project]
 name = "huggingbutt"
 version = "0.0.1c"


### PR DESCRIPTION
The 'images' folder contains the images for README.md. Setting a 'py-modules' variable in pyproject.toml will avoid error of having multiple top-level modules at installation.